### PR TITLE
Fix config import and README diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ graph LR
     API --> MapsDB[(PostGIS)]
     API --> Schedule[(Schedule Service)]
   end
-  MapsDB --> {OpenStreetMap data}
+  MapsDB --> OSData[(OpenStreetMap data)]
 ```
 
 ### Быстрый старт

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -1,4 +1,4 @@
-from pydantic import BaseSettings
+from pydantic_settings import BaseSettings
 
 class Settings(BaseSettings):
     database_url: str = "sqlite:///./geomisis.db"

--- a/backend/app/requirements.txt
+++ b/backend/app/requirements.txt
@@ -2,5 +2,6 @@ fastapi
 uvicorn
 SQLAlchemy
 pydantic
+pydantic-settings
 python-multipart
 


### PR DESCRIPTION
## Summary
- switch to `pydantic-settings` for BaseSettings
- add new dependency to backend requirements
- correct mermaid diagram in README

## Testing
- `pip install -r backend/app/requirements.txt`
- `python -m compileall -q backend/app`


------
https://chatgpt.com/codex/tasks/task_e_684f14ae76e4832080e909c76804b7bb