### PR TITLE
Fix nav icon color

### DIFF
--- a/frontend/lib/screens/home_screen.dart
+++ b/frontend/lib/screens/home_screen.dart
@@ -27,6 +27,8 @@ class _HomeScreenState extends State<HomeScreen> {
       bottomNavigationBar: BottomNavigationBar(
         currentIndex: _index,
         onTap: (i) => setState(() => _index = i),
+        selectedItemColor: Theme.of(context).colorScheme.primary,
+        unselectedItemColor: Colors.black54,
         items: const [
           BottomNavigationBarItem(icon: Icon(Icons.search), label: 'Поиск'),
           BottomNavigationBarItem(icon: Icon(Icons.directions), label: 'Маршрут'),


### PR DESCRIPTION
## Summary
- ensure bottom navigation icons use visible colors

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f25c72ab883209e49e800c7be4fa7